### PR TITLE
feat: sort research team members and documents by name and description for improved organization

### DIFF
--- a/src/pages/research-teams/[slug].astro
+++ b/src/pages/research-teams/[slug].astro
@@ -104,14 +104,17 @@ const { entry } = Astro.props;
     <h2 class="text-xl font-semibold text-white bg-black py-4 px-48 w-fit mx-auto mb-16 text-center">Members</h2>
     <div class="container max-w-screen-xl mx-auto px-4 py-1">
       <div class="grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 p-8">
-        {entry.data.members.map(member => (
-          <ItemProfile
-            categoryId={member.cvlac}
-            name={member.name}
-            image={member.image}
-            cvlac={member.cvlac}
-            orcid={member.orcid}
-          />
+        {entry.data.members
+          .slice()
+          .sort((a, b) => a.name.localeCompare(b.name))
+          .map(member => (
+        <ItemProfile
+          categoryId={member.cvlac}
+          name={member.name}
+          image={member.image}
+          cvlac={member.cvlac}
+          orcid={member.orcid}
+        />
         ))}
       </div>
     </div>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -25,27 +25,30 @@ const documents = documentEntries[0]?.data.documents || [];
 
       <!-- Results -->
       <div class="max-w-3xl mx-auto grid grid-cols-1 sm:grid-cols-2 gap-6" id="resultsList">
-        {documents.map((doc) => (
-  <div
-    class="bg-white rounded-lg shadow hover:shadow-md transition p-6 flex flex-col text-left gap-4 border border-gray-100"
-    data-name={doc.name}
-    data-description={doc.description}
-  >
-    <strong class="text-xl font-semibold text-gray-800">{doc.name}</strong>
-    <p class="text-gray-600">{doc.description}</p>
+        {documents
+          .slice()
+          .sort((a, b) => a.description.localeCompare(b.description))
+          .map((doc) => (
+        <div
+          class="bg-white rounded-lg shadow hover:shadow-md transition p-6 flex flex-col text-left gap-4 border border-gray-100"
+          data-name={doc.name}
+          data-description={doc.description}
+        >
+          <strong class="text-xl font-semibold text-gray-800">{doc.name}</strong>
+          <p class="text-gray-600">{doc.description}</p>
 
-    <a
-      href={doc.link}
-      target="_blank"
-      rel="noopener noreferrer"
-      download
-      class="mt-auto inline-flex items-center text-sm text-rose-500 hover:text-rose-600 font-medium"
-    >
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-1" fill="currentColor" viewBox="0 0 24 24">
-        <path d="M6 2a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8.828A2 2 0 0 0 19.414 8L16 4.586A2 2 0 0 0 14.828 4H6zm7 1.414L18.586 7H15a2 2 0 0 1-2-2V3.414zM6 4h7v3a4 4 0 0 0 4 4h3v11a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4zm2 8h8v2H8v-2zm0 4h5v2H8v-2z"/>
-      </svg>
-      Descargar PDF
-    </a>
+          <a
+            href={doc.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            download
+            class="mt-auto inline-flex items-center text-sm text-rose-500 hover:text-rose-600 font-medium"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-1" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M6 2a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8.828A2 2 0 0 0 19.414 8L16 4.586A2 2 0 0 0 14.828 4H6zm7 1.414L18.586 7H15a2 2 0 0 1-2-2V3.414zM6 4h7v3a4 4 0 0 0 4 4h3v11a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4zm2 8h8v2H8v-2zm0 4h5v2H8v-2z"/>
+            </svg>
+            Descargar PDF
+          </a>
   </div>
 ))}
 


### PR DESCRIPTION
This pull request introduces sorting functionality to improve the user experience by displaying lists in a more organized manner. Specifically, it ensures that members and documents are displayed in alphabetical order based on their names or descriptions.

### Sorting improvements:

* `src/pages/research-teams/[slug].astro`: Added sorting to the `members` array, ensuring that team members are displayed in alphabetical order by their names. ([src/pages/research-teams/[slug].astroL107-R110](diffhunk://#diff-793b5f06980b81bcd723003bb2264fc15cd16c60a8bbf17bcd48f841c7871d13L107-R110))
* [`src/pages/search.astro`](diffhunk://#diff-e2b8913c5806f07846adec86a83dea4008cf016ca7fffd7d4e4a62b85359d398L28-R31): Added sorting to the `documents` array, ensuring that documents are displayed in alphabetical order by their descriptions.